### PR TITLE
Add OpenAPI spec generation helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 __pycache__/
 .DS_Store
 .coverage
+
+# Local virtual environment
+.venv/
+openapi_spec.json
+poetry.lock

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 An implementation of the
 [Poe protocol](https://creator.poe.com/docs/poe-protocol-specification) using FastAPI.
 
+### Installation
+
+Install the package from PyPI:
+
+```bash
+pip install fastapi-poe
+```
+
 ### Write your own bot
 
 This package can also be used as a base to write your own bot. You can inherit from

--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ if __name__ == "__main__":
 Check out our starter code
 [repository](https://github.com/poe-platform/server-bot-quick-start) for some examples
 you can use to get started with bot development.
+
+### Generate an OpenAPI specification
+
+Run `.venv/bin/python docs/generate_openapi_spec.py` to write `openapi_spec.json` describing the HTTP endpoints.

--- a/docs/generate_openapi_spec.py
+++ b/docs/generate_openapi_spec.py
@@ -1,0 +1,37 @@
+"""
+Generate an OpenAPI specification for a simple ``fastapi_poe`` application.
+
+Usage::
+
+    .venv/bin/python docs/generate_openapi_spec.py
+
+The specification will be written to ``openapi_spec.json`` in the current
+working directory.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+sys.path.append("../src")
+
+import fastapi_poe as fp
+
+
+class EchoBot(fp.PoeBot):
+    async def get_response(
+        self, request: fp.QueryRequest
+    ) -> fp.AsyncIterable[fp.PartialResponse]:
+        yield fp.PartialResponse(text="hello")
+
+
+def main() -> None:
+    app = fp.make_app(EchoBot(path="/bot", access_key="dummy"), allow_without_key=True)
+    spec = app.openapi()
+    with open("openapi_spec.json", "w") as f:
+        json.dump(spec, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `generate_openapi_spec.py` helper for producing an OpenAPI schema
- document how to generate a spec
- ignore local artifacts like `.venv/`

## Testing
- `pytest -q`
- `python docs/generate_openapi_spec.py`
